### PR TITLE
FIX | separator in the end

### DIFF
--- a/src/nymo/Resources/Views/breadcrumbs.html.twig
+++ b/src/nymo/Resources/Views/breadcrumbs.html.twig
@@ -9,8 +9,8 @@
             {{ breadcrumb.linkName|trans }}
         {% else %}
             <a href="{{ breadcrumb.target }}">{{ breadcrumb.linkName|trans }}</a>
+            {{ separator }}
         {% endif %}
-        {{ separator }}
         </li>
     {% endfor %}
 </ul>


### PR DESCRIPTION
no need for a separator at the end of the breadcrumbs, because the last is the actual page, and first, a separator is useless if it doesn't separate something from another :+1: 